### PR TITLE
Twitterでシェアするさいに、Tier画像をOGPとして設定する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem "image_processing", "~> 1.2"
 gem 'sorcery'
 gem 'rails-i18n', '~> 7.0.0'
 gem "aws-sdk-s3", require: false
+gem "meta-tags"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
       net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
+    meta-tags (2.18.0)
+      actionpack (>= 3.2.0, < 7.1)
     method_source (1.0.0)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
@@ -355,6 +357,7 @@ DEPENDENCIES
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
+  meta-tags
   pg (~> 1.1)
   pry-byebug
   puma (~> 5.0)

--- a/app/controllers/tiers_controller.rb
+++ b/app/controllers/tiers_controller.rb
@@ -98,6 +98,6 @@ class TiersController < ApplicationController
   private
 
   def tier_params
-    params.require(:tier).permit(:category_id, :title, :description)
+    params.require(:tier).permit(:category_id, :title, :description, :cover_image)
   end
 end

--- a/app/controllers/tiers_controller.rb
+++ b/app/controllers/tiers_controller.rb
@@ -1,4 +1,6 @@
 class TiersController < ApplicationController
+  include ApplicationHelper
+
   def index; end
 
   def show
@@ -12,6 +14,14 @@ class TiersController < ApplicationController
 
   def edit
     @tier = Tier.find(params[:id])
+
+    set_meta_tags title: @tier.title,
+    og: {
+      image: url_for(@tier.cover_image.blob.url)
+    },
+    twitter: {
+      image: url_for(@tier.cover_image.blob.url)
+    }
 
     tier_categories = TierCategory.where(tier_id: @tier.id).order(:order)
     tier_ranks = TierRank.where(tier_id: @tier.id).order(:order)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,29 @@
 module ApplicationHelper
+  def default_meta_tags
+    image_path = image_url('top_logo.png')
+    {
+      site: 'Tier工房',
+      title: 'Tierを作成しよう!',
+      reverse: true,
+      charset: 'utf-8',
+      description: 'Tier工房を使えばあなただけのランキングを作成できます。',
+      keywords: 'tier',
+      canonical: request.original_url,
+      separator: '|',
+      og: {
+        site_name: :site,
+        title: :title,
+        description: :description,
+        type: 'website',
+        url: request.original_url,
+        image: image_path,
+        local: 'ja-JP'
+      },
+      twitter: {
+        card: 'summary_large_image',
+        site: '@',
+        image: image_path
+      }
+    }
+  end
 end

--- a/app/models/tier.rb
+++ b/app/models/tier.rb
@@ -7,4 +7,6 @@ class Tier < ApplicationRecord
   has_many :items, dependent: :destroy
 
   validates :title, presence: true
+
+  has_one_attached :cover_image
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <%= display_meta_tags(default_meta_tags) %>
   </head>
 
   <body>

--- a/app/views/tiers/_form.html.erb
+++ b/app/views/tiers/_form.html.erb
@@ -11,9 +11,9 @@
     <%= f.label :description, Tier.human_attribute_name(:description), class: 'control-label' %>
     <%= f.text_area :description, class: 'form-control' %>
   </div>
-    <div class="form-group mb-4">
-    <%= f.label :cover_images, Tier.human_attribute_name(:cover_image), class: 'control-label d-block' %>
-    <%= f.file_field :images, accept: 'image/png,image/jpeg', class: 'form-control-file' %>
+  <div class="form-group mb-4">
+    <%= f.label :cover_image, Tier.human_attribute_name(:cover_image), class: 'control-label d-block' %>
+    <%= f.file_field :cover_image, accept: 'image/png,image/jpeg', class: 'form-control-file' %>
   </div>
   <div class="form-group mb-4">
     <%= f.label :images, Tier.human_attribute_name(:images), class: 'control-label d-block' %>

--- a/app/views/tiers/_form.html.erb
+++ b/app/views/tiers/_form.html.erb
@@ -11,6 +11,10 @@
     <%= f.label :description, Tier.human_attribute_name(:description), class: 'control-label' %>
     <%= f.text_area :description, class: 'form-control' %>
   </div>
+    <div class="form-group mb-4">
+    <%= f.label :cover_images, Tier.human_attribute_name(:cover_image), class: 'control-label d-block' %>
+    <%= f.file_field :images, accept: 'image/png,image/jpeg', class: 'form-control-file' %>
+  </div>
   <div class="form-group mb-4">
     <%= f.label :images, Tier.human_attribute_name(:images), class: 'control-label d-block' %>
     <%= f.file_field :images, accept: 'image/png,image/jpeg', class: 'form-control-file', multiple: true, id: 'image-upload' %>

--- a/config/initializers/meta_tags.rb
+++ b/config/initializers/meta_tags.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Use this setup block to configure all options available in MetaTags.
+MetaTags.configure do |config|
+  # How many characters should the title meta tag have at most. Default is 70.
+  # Set to nil or 0 to remove limits.
+  # config.title_limit = 70
+
+  # When true, site title will be truncated instead of title. Default is false.
+  # config.truncate_site_title_first = false
+
+  # Maximum length of the page description. Default is 300.
+  # Set to nil or 0 to remove limits.
+  # config.description_limit = 300
+
+  # Maximum length of the keywords meta tag. Default is 255.
+  # config.keywords_limit = 255
+
+  # Default separator for keywords meta tag (used when an Array passed with
+  # the list of keywords). Default is ", ".
+  # config.keywords_separator = ', '
+
+  # When true, keywords will be converted to lowercase, otherwise they will
+  # appear on the page as is. Default is true.
+  # config.keywords_lowercase = true
+
+  # When true, the output will not include new line characters between meta tags.
+  # Default is false.
+  # config.minify_output = false
+
+  # When false, generated meta tags will be self-closing (<meta ... />) instead
+  # of open (`<meta ...>`). Default is true.
+  # config.open_meta_tags = true
+
+  # List of additional meta tags that should use "property" attribute instead
+  # of "name" attribute in <meta> tags.
+  # config.property_tags.push(
+  #   'x-hearthstone:deck',
+  # )
+end

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -12,5 +12,6 @@ ja:
       tier:
         category_id: 'カテゴリ'
         images: '画像'
+        cover_image: 'カバー画像'
         title: 'タイトル'
         description: '説明'


### PR DESCRIPTION
## このプルリクエストで何をしたのか
Twitterでシェアするさいに、Tier画像をOGPとして設定する

## 対象issue
<!-- 例) close #12 -->
close #125 

## 参考情報

## 備考