### PR TITLE
Tier作成画面と設定画面の画面の修正

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -104,7 +104,7 @@
 }
 
 .container {
-  margin-bottom: 72px;
+  padding-bottom: 72px;
   max-width: 1600px;
 }
 
@@ -114,4 +114,8 @@
 
 .tier-row, .category-row {
   @extend .row-flex;
+}
+
+.me-custom {
+  margin-right: 20rem;
 }

--- a/app/controllers/tiers_controller.rb
+++ b/app/controllers/tiers_controller.rb
@@ -88,7 +88,7 @@ class TiersController < ApplicationController
             else
               "#{item.tier_rank_id}_#{item.tier_category_id}"
             end
-      variant = item.image.variant(resize_to_limit: [50, nil]).processed
+      variant = item.image.variant(resize_to_limit: [80, nil]).processed
       image_data = {
         url: url_for(variant.url),
         id: item.id

--- a/app/views/tiers/_form.html.erb
+++ b/app/views/tiers/_form.html.erb
@@ -4,12 +4,12 @@
     <%= f.select :category_id, categories.collect { |c| [c.name, c.id] }, {}, { class: 'form-control' } %>
   </div>
   <div class="form-group mb-4">
-    <%= f.label :title, Tier.human_attribute_name(:title), class: 'control-label' %>
-    <%= f.text_field :title, class: 'form-control' %>
+      <%= f.label :title, Tier.human_attribute_name(:title), class: 'control-label' %>
+      <%= f.text_field :title, class: 'form-control', placeholder: 'タイトル' %>
   </div>
   <div class="form-group mb-4">
-    <%= f.label :description, Tier.human_attribute_name(:description), class: 'control-label' %>
-    <%= f.text_area :description, class: 'form-control' %>
+      <%= f.label :description, Tier.human_attribute_name(:description), class: 'control-label' %>
+      <%= f.text_area :description, class: 'form-control', placeholder: '説明文' %>
   </div>
   <div class="form-group mb-4">
     <%= f.label :cover_image, Tier.human_attribute_name(:cover_image), class: 'control-label d-block' %>
@@ -24,11 +24,12 @@
   <div class="form-group mb-4">
     <label class='control-label'><%= t('.rank') %></label>
     <%= f.fields_for :tier_ranks do |rank_form| %>
+      <% rank_placeholders = ["S", "A", "B", "C", "D"] %>
       <% if rank_form.index.zero? %>
         <%= rank_form.hidden_field :name, value: 'unranked' %>
         <%= rank_form.hidden_field :order, value: 0 %>
       <% else %>
-        <%= rank_form.text_field :name, class: 'form-control mt-2' %>
+        <%= rank_form.text_field :name, class: 'form-control mt-2', placeholder: rank_placeholders[rank_form.index - 1] %>
         <%= rank_form.hidden_field :order, value: rank_form.index %>
       <% end %>
     <% end %>
@@ -37,11 +38,12 @@
   <div class="form-group mb-4">
     <label class='control-label'><%= t('.category') %></label>
     <%= f.fields_for :tier_categories do |category_form| %>
+      <% category_placeholders = ["Jungle", "Roam", "Exp", "Gold", "Mid"] %>
       <% if category_form.index.zero? %>
         <%= category_form.hidden_field :name, value: 'uncategorized' %>
         <%= category_form.hidden_field :order, value: 0 %>
       <% else %>
-        <%= category_form.text_field :name, class: 'form-control mt-2' %>
+        <%= category_form.text_field :name, class: 'form-control mt-2', placeholder: category_placeholders[category_form.index - 1] %>
         <%= category_form.hidden_field :order, value: category_form.index %>
       <% end %>
     <% end %>

--- a/app/views/tiers/_save_image_modal.html.erb
+++ b/app/views/tiers/_save_image_modal.html.erb
@@ -1,0 +1,17 @@
+<div class="modal fade" id="save-image-modal" tabindex="-1" aria-labelledby="saveImageModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="saveImageModalLabel">モーダルのタイトル</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p>これはモーダルのコンテンツです。</p>
+      </div>
+      <div class="modal-footer">
+        <%= button_tag 'ダウンロード', type: 'button', class: 'btn btn-primary', id: 'download-image-button' %>
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/tiers/make.html.erb
+++ b/app/views/tiers/make.html.erb
@@ -1,4 +1,11 @@
 <div class="container">
+  <h1 class="mb-3"><%= @tier.title %></h1>
+  
+  <p class="mb-4"><%= @tier.description %></p>
+
+  <%= link_to "https://twitter.com/intent/tweet?text=Hello,%20World!%20(from%20@gem)&url=#{CGI.escape(request.original_url)}", target: "_blank", class: "btn btn-primary" do %>
+    <i class="fab fa-twitter"></i> Tweet
+  <% end %>
   <div id="tier-container" data-tier-id="<%= @tier.id %>">
     <div class="category-row">
       <div class="label-holder"></div>
@@ -21,16 +28,17 @@
       </div>
     <% end %>
   </div>
-  <div id="default-area" class="d-flex justify-content-center border border-dark rounded p-3" data-default-category-id="<%= @category_id_with_order_zero %>" data-default-rank-id="<%= @rank_id_with_order_zero %>">
+  <div id="default-area" class="d-flex justify-content-center border border-dark rounded p-3 mb-3" data-default-category-id="<%= @category_id_with_order_zero %>" data-default-rank-id="<%= @rank_id_with_order_zero %>">
     <% (@images_map["uncategorized_unranked"] || []).each do |image_data| %>
       <%= image_tag image_data[:url], id: image_data[:id], crossorigin: "anonymous", draggable: "true" %>
     <% end %>
   </div>
-  <%= button_tag '保存', type: 'button', class: 'btn btn-primary', data: { bs_toggle: 'modal', bs_target: '#save-image-modal' } %>
-  <%= link_to "https://twitter.com/intent/tweet?text=Hello,%20World!%20(from%20@gem)&url=#{CGI.escape(request.original_url)}", target: "_blank", class: "btn btn-primary" do %>
-    <i class="fab fa-twitter"></i> Tweet
-  <% end %>
-  <%= link_to '編集', edit_tier_path(@tier), class: 'btn btn-primary' %>
-  <%= link_to '削除', tier_path(@tier), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-danger' %>
+
+<div class="d-flex justify-content-center mb-3 mx-4 px-4">
+    <%= button_tag '保存', type: 'button', class: 'btn btn-secondary btn-lg me-custom', data: { bs_toggle: 'modal', bs_target: '#save-image-modal' } %>
+    <%= link_to '編集', edit_tier_path(@tier), class: 'btn btn-primary btn-lg me-custom' %>
+    <%= link_to '削除', tier_path(@tier), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-danger btn-lg' %>
+</div>
+
   <%= render 'save_image_modal' %>
 </div>

--- a/app/views/tiers/make.html.erb
+++ b/app/views/tiers/make.html.erb
@@ -32,21 +32,5 @@
   <% end %>
   <%= link_to '編集', edit_tier_path(@tier), class: 'btn btn-primary' %>
   <%= link_to '削除', tier_path(@tier), data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'btn btn-danger' %>
-  <div class="modal fade" id="save-image-modal" tabindex="-1" aria-labelledby="saveImageModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="saveImageModalLabel">モーダルのタイトル</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <div class="modal-body">
-          <p>これはモーダルのコンテンツです。</p>
-        </div>
-        <div class="modal-footer">
-          <%= button_tag 'ダウンロード', type: 'button', class: 'btn btn-primary', id: 'download-image-button' %>
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">閉じる</button>
-        </div>
-      </div>
-    </div>
-  </div>
+  <%= render 'save_image_modal' %>
 </div>


### PR DESCRIPTION
## このプルリクエストで何をしたのか
- Tier作成画面のボタンレイアウトを整える
- Tier設定画面にプレスホルダー追加
- モーダルを部分テンプレートに書き出す
- Tier作成画面にタイトルと説明文が表示されるようにした

## 対象issue
<!-- 例) close #12 -->
close #167 
close #163 
close #165  


## 参考情報

## 備考